### PR TITLE
Update link to instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,10 @@ You also agree to abide by our
 2.  For our lessons,
     you should branch from and submit pull requests against the `gh-pages` branch.
 
-3.  When editing lesson pages, you need only commit changes to the Markdown source files.
+3.  When editing lessons, please only commit changes to the Markdown
+    files, *not* the generated HTML.  We will re-create the HTML after
+    your pull request is merged.  (Working this way ensures that each
+    change only needs to be reviewed once, in one place.)
 
 4.  If you're looking for things to work on,
     please see [the list of issues for this repository][issues],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ You also agree to abide by our
     Feel free to contact them if you have any questions or languishing pull requests.
 
 [conduct]: CONDUCT.md
-[issues]: https://github.com/swcarpentry/lesson-template/issues
+[issues]: https://github.com/swcarpentry/modern-scientific-authoring/issues
 [license]: LICENSE.md
 [pro-git-chapter]: http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project
 [swc-lessons]: http://software-carpentry.org/lessons.html

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# modern-scientific-authoring
+modern-scientific-authoring
+===========================
+
 How to write, publish, and review scientific papers in the early 21st Century
+
+> Please see [https://github.com/swcarpentry/lesson-example](https://github.com/swcarpentry/lesson-example)
+> for instructions on formatting, building, and submitting lessons,
+> or run `make` in this directory for a list of helpful commands.


### PR DESCRIPTION
Pointing at lesson-example instead of lesson-template, and telling people (again) not to commit HTML.
